### PR TITLE
Extend appinfo configuration

### DIFF
--- a/www/appinfo.json.tmpl
+++ b/www/appinfo.json.tmpl
@@ -8,9 +8,9 @@
   "icon": "{{{icon}}}",
   "largeIcon": "{{{largeicon}}}",
   "resolution": "{{{resolution}}}",
-  "bgColor": "{{{bgColor}}}",
-  "iconColor": "{{{iconColor}}}",
-  "bgImage": "{{{bgImage}}}",
-  "splashBackground": "{{{splashBackground}}}",
+  "bgColor": "{{{bgcolor}}}",
+  "iconColor": "{{{iconcolor}}}",
+  "bgImage": "{{{bgimage}}}",
+  "splashBackground": "{{{splashbackground}}}",
   "disableBackHistoryAPI": true
 }

--- a/www/appinfo.json.tmpl
+++ b/www/appinfo.json.tmpl
@@ -8,5 +8,9 @@
   "icon": "{{{icon}}}",
   "largeIcon": "{{{largeicon}}}",
   "resolution": "{{{resolution}}}",
+  "bgColor": "{{{bgColor}}}",
+  "iconColor": "{{{iconColor}}}",
+  "bgImage": "{{{bgImage}}}",
+  "splashBackground": "{{{splashBackground}}}",
   "disableBackHistoryAPI": true
 }


### PR DESCRIPTION
On WebOS, you are able to configure application icon background, splash screen, and hover image from appinfo.json.
With this pull request, developers are able to configure the webOS builds better.

This pull request is connected to my [grunt-cordova-sectv](https://github.com/Samsung/grunt-cordova-sectv/pull/12) request.